### PR TITLE
Menu incomplete - targeting the correct element again

### DIFF
--- a/run.user.js
+++ b/run.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Google image sizer
 // @namespace    https://github.com/danieljbingham/google-image-sizer
-// @version      1.0.3.6
+// @version      1.0.3.7
 // @description  re-implement Google Images size filter
 // @author       Daniel Bingham
 // @include      http*://*.google.tld/search*tbm=isch*
@@ -83,7 +83,7 @@
 		if (parent.classList.contains('szDone')) return;
 		parent.classList.add('szDone');
 		icon.href = icon.href.replace(/(tbs=[^&]*)/, function(s){return unescape(s)} );
-		var cur = parent.querySelector('span.MfLWbb');
+		var cur = parent.querySelector('span.MfLWbb, .MfLWbb:not([href])');
 		for (var i = 0; i < sizes.length; i++) {
 			let clone = icon.cloneNode(true);
 			clone.id = sizes[i][0];


### PR DESCRIPTION
The html tag of the current menu selection has changed. I don't know when they changed it. When I change the size choice I rarely go back to the menu. And it has been a while since I last searched for bigger images.
This is an update of the queryselector.

The symptom was that only sizes smaller than the current size were added to the menu.
This fixes the issue.

Note: With google, I always left the previous selector in `querySelector()` in case they play with both layouts. Feel free to remove the old selector.